### PR TITLE
Treat HTTP 403 responses like 401 ones to prevent infinite loops 

### DIFF
--- a/tomcat.py
+++ b/tomcat.py
@@ -110,7 +110,7 @@ class Tomcat(object):
 				stop = True
 				if 'Set-Cookie' in snd_hdrs_res.response_headers:
 					logger.info("Here is your cookie: %s" % (snd_hdrs_res.response_headers.get('Set-Cookie', '')))
-			elif snd_hdrs_res.http_status_code == 401:
+			elif snd_hdrs_res.http_status_code in (401, 403):
 				stop = True
 
 		return res


### PR DESCRIPTION
(fixed previous failed PR)

In some cases, Tomcat gives both 401 and 403 responses (I don't know why), and 403 responses were triggering infinite loops.

Maybe a better fix would be to replace this final "elif" by a catch-all "else", I don't know if you had something else in mind.
- [x] checked on a real case
